### PR TITLE
fix #3236

### DIFF
--- a/openbb_terminal/stocks/stocks_controller.py
+++ b/openbb_terminal/stocks/stocks_controller.py
@@ -546,6 +546,7 @@ class StocksController(StockBaseController):
             "--sources",
             dest="sources",
             type=str,
+            default="",
             help="Show news only from the sources specified (e.g bloomberg,reuters)",
         )
         if other_args and "-" not in other_args[0][0]:


### PR DESCRIPTION
fix /sources/news sources display error. (#3236)

# Description
Fix #3236

![image](https://user-images.githubusercontent.com/23350634/199301546-f7b67475-92e7-4416-8667-5af4e7b4d478.png)

fixed with news showing from all sources if sources parameter is not indicated

![image](https://user-images.githubusercontent.com/23350634/199301966-fd3cd951-48b9-422f-bf43-32967b95951b.png)


# How has this been tested?
i used vscode debugger. 
found that there's no default value for sources in the namespace parser.


# Checklist:

- [ ] Update [our Hugo documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).
- [ ] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [ ] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [ ] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/scripts).


# Others
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
